### PR TITLE
Validate web3signer signatures

### DIFF
--- a/shared/utils/eth2/eth2.go
+++ b/shared/utils/eth2/eth2.go
@@ -20,7 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package eth2
 
 import (
+	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
 	"github.com/stader-labs/stader-node/shared/services/beacon"
+	"github.com/stader-labs/stader-node/stader-lib/types"
 )
 
 // Get an eth2 epoch number by time
@@ -53,4 +55,26 @@ func IsValidatorActive(validatorStatus beacon.ValidatorStatus) bool {
 	}
 
 	return false
+}
+
+func VerifyBlsSignatures(validatorPubKey types.ValidatorPubkey, msg [32]byte, signature types.ValidatorSignature) (bool, error) {
+	signaturesToVerify := [][]byte{}
+	signaturesToVerify = append(signaturesToVerify, signature.Bytes())
+
+	msgsSigned := [][32]byte{}
+	msgsSigned = append(msgsSigned, msg)
+
+	pubKey, err := bls.PublicKeyFromBytes(validatorPubKey[:])
+	if err != nil {
+		return false, err
+	}
+	pubKeys := []bls.PublicKey{}
+	pubKeys = append(pubKeys, pubKey)
+
+	res, err := bls.VerifyMultipleSignatures(signaturesToVerify, msgsSigned, pubKeys)
+	if err != nil {
+		return false, err
+	}
+
+	return res, nil
 }

--- a/shared/utils/validator/deposit-data.go
+++ b/shared/utils/validator/deposit-data.go
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package validator
 
 import (
-	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stader-labs/stader-node/shared/types/eth2"
 	"github.com/stader-labs/stader-node/stader-lib/types"
@@ -79,7 +78,6 @@ func GetDepositDataSigningRoot(validatorPubKey string, withdrawCredentials commo
 	if err != nil {
 		return eth2.DepositDataNoSignature{}, common.Hash{}, err
 	}
-	fmt.Printf("validatorPubKeyHex: %s", validatorPubKeyHex.String())
 	dd := eth2.DepositDataNoSignature{
 		PublicKey:             validatorPubKeyHex[:],
 		WithdrawalCredentials: withdrawCredentials[:],

--- a/shared/utils/validator/voluntary-exit.go
+++ b/shared/utils/validator/voluntary-exit.go
@@ -58,3 +58,30 @@ func GetSignedExitMessage(validatorKey *eth2types.BLSPrivateKey, validatorIndex 
 	return types.BytesToValidatorSignature(signature), srHash, nil
 
 }
+
+func GetExitMessageHash(validatorIndex uint64, epoch uint64, signatureDomain []byte) ([32]byte, error) {
+	// Build voluntary exit message
+	exitMessage := eth2.VoluntaryExit{
+		Epoch:          epoch,
+		ValidatorIndex: validatorIndex,
+	}
+
+	// Get object root
+	or, err := exitMessage.HashTreeRoot()
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	// Get signing root
+	sr := eth2.SigningRoot{
+		ObjectRoot: or[:],
+		Domain:     signatureDomain,
+	}
+
+	srHash, err := sr.HashTreeRoot()
+	if err != nil {
+		return [32]byte{}, nil
+	}
+
+	return srHash, nil
+}

--- a/shared/version.go
+++ b/shared/version.go
@@ -21,7 +21,7 @@ package shared
 
 const BinaryBucket string = "/stader-node-build/permissioned"
 const DockerAccount string = "staderlabs"
-const StaderVersion string = "1.2.0"
+const StaderVersion string = "1.2.1"
 
 const Logo string = ` 
   _____ _            _             _           _       𝅺 	

--- a/stader/api/validator/register.go
+++ b/stader/api/validator/register.go
@@ -182,11 +182,11 @@ func canRegisterValidators(c *cli.Context, validatorList string) (*api.CanRegist
 			return nil, err
 		}
 
-		_, preDepositRootHash, err := validator.GetDepositDataSigningRoot(validatorPubkey, withdrawCredentials, eth2Config, 1000000000)
+		_, preDepositRootHash, err := validator.GetDepositDataSigningRoot(validatorPubkey[2:], withdrawCredentials, eth2Config, 1000000000)
 		if err != nil {
 			return nil, err
 		}
-		_, depositRootHash, err := validator.GetDepositDataSigningRoot(validatorPubkey, withdrawCredentials, eth2Config, 31000000000)
+		_, depositRootHash, err := validator.GetDepositDataSigningRoot(validatorPubkey[2:], withdrawCredentials, eth2Config, 31000000000)
 		if err != nil {
 			return nil, err
 		}

--- a/stader/node/node.go
+++ b/stader/node/node.go
@@ -223,11 +223,13 @@ func run(c *cli.Context) error {
 
 					exitEpoch := currentHead.Epoch
 
+					infoLog.Printf("Getting signature domain\n")
 					signatureDomain, err := bc.GetDomainData(eth2types.DomainVoluntaryExit[:], exitEpoch, false)
 					if err != nil {
 						errorLog.Printf("Failed to get the signature domain from beacon chain with err: %s\n", err.Error())
 						continue
 					}
+					infoLog.Printf("Getting exit message hash\n")
 					srHash, err := validator.GetExitMessageHash(validatorStatus.Index, exitEpoch, signatureDomain)
 					if err != nil {
 						errorLog.Printf("Failed to generate srHash for exit message: %s\n", err.Error())
@@ -247,6 +249,7 @@ func run(c *cli.Context) error {
 						continue
 					}
 
+					infoLog.Printlnf("Verifying signature\n")
 					res, err := eth2.VerifyBlsSignatures(validatorPubKey, srHash, signature)
 					if err != nil {
 						errorLog.Printf("Error verifying exit signature: %s\n", err.Error())
@@ -256,6 +259,7 @@ func run(c *cli.Context) error {
 						errorLog.Printf("Exit signature generated is invalid\n")
 						continue
 					}
+					infoLog.Printlnf("Successfully verified signature!")
 
 					// encrypt the signature and srHash
 					exitSignatureEncrypted, err := crypto.EncryptUsingPublicKey([]byte(signature.String()), publicKey)

--- a/stader/node/node.go
+++ b/stader/node/node.go
@@ -223,13 +223,11 @@ func run(c *cli.Context) error {
 
 					exitEpoch := currentHead.Epoch
 
-					infoLog.Printf("Getting signature domain\n")
 					signatureDomain, err := bc.GetDomainData(eth2types.DomainVoluntaryExit[:], exitEpoch, false)
 					if err != nil {
 						errorLog.Printf("Failed to get the signature domain from beacon chain with err: %s\n", err.Error())
 						continue
 					}
-					infoLog.Printf("Getting exit message hash\n")
 					srHash, err := validator.GetExitMessageHash(validatorStatus.Index, exitEpoch, signatureDomain)
 					if err != nil {
 						errorLog.Printf("Failed to generate srHash for exit message: %s\n", err.Error())
@@ -249,7 +247,6 @@ func run(c *cli.Context) error {
 						continue
 					}
 
-					infoLog.Printlnf("Verifying signature\n")
 					res, err := eth2.VerifyBlsSignatures(validatorPubKey, srHash, signature)
 					if err != nil {
 						errorLog.Printf("Error verifying exit signature: %s\n", err.Error())
@@ -259,7 +256,6 @@ func run(c *cli.Context) error {
 						errorLog.Printf("Exit signature generated is invalid\n")
 						continue
 					}
-					infoLog.Printlnf("Successfully verified signature!")
 
 					// encrypt the signature and srHash
 					exitSignatureEncrypted, err := crypto.EncryptUsingPublicKey([]byte(signature.String()), publicKey)


### PR DESCRIPTION
Fixes a Low Audit report issue from Sigma prime where it was suggested to validate web3signer signatures before sending them to the backend.