### PR TITLE
Ignore cycles with no rewards while claiming all rewards

### DIFF
--- a/shared/version.go
+++ b/shared/version.go
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package shared
 
 const BinaryBucket string = "/stader-node-build/permissioned"
-const DockerAccount string = "staderdev"
+const DockerAccount string = "staderlabs"
 const StaderVersion string = "1.3.1"
 
 const Logo string = ` 

--- a/shared/version.go
+++ b/shared/version.go
@@ -20,8 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package shared
 
 const BinaryBucket string = "/stader-node-build/permissioned"
-const DockerAccount string = "staderlabs"
-const StaderVersion string = "1.2.1"
+const DockerAccount string = "staderdev"
+const StaderVersion string = "1.3.1"
 
 const Logo string = ` 
   _____ _            _             _           _       𝅺 	

--- a/stader-cli/node/claim-sp-rewards.go
+++ b/stader-cli/node/claim-sp-rewards.go
@@ -2,15 +2,16 @@ package node
 
 import (
 	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
 	"github.com/stader-labs/stader-node/shared/services/gas"
 	"github.com/stader-labs/stader-node/shared/services/stader"
 	cliutils "github.com/stader-labs/stader-node/shared/utils/cli"
 	"github.com/stader-labs/stader-node/shared/utils/math"
 	"github.com/stader-labs/stader-node/stader-lib/utils/eth"
 	"github.com/urfave/cli"
-	"math/big"
-	"strconv"
-	"strings"
 )
 
 func ClaimSpRewards(c *cli.Context) error {
@@ -20,9 +21,12 @@ func ClaimSpRewards(c *cli.Context) error {
 	}
 	defer staderClient.Close()
 
-	_, err = staderClient.DownloadSpMerkleProofs()
+	downloadRes, err := staderClient.DownloadSpMerkleProofs()
 	if err != nil {
 		return err
+	}
+	if len(downloadRes.DownloadedCycles) != 0 {
+		fmt.Printf("Merkle proofs downloaded for cycles %v!\n", downloadRes.DownloadedCycles)
 	}
 
 	// prompt user to select the cycles to claim from
@@ -52,6 +56,13 @@ func ClaimSpRewards(c *cli.Context) error {
 
 	cycleIndexes := []*big.Int{}
 	for _, cycleInfo := range detailedCyclesInfo.DetailedCyclesInfo {
+		ethRewards, ok := big.NewInt(0).SetString(cycleInfo.MerkleProofInfo.Eth, 10)
+		if !ok {
+			return fmt.Errorf("Unable to parse eth rewards: %s", cycleInfo.MerkleProofInfo.Eth)
+		}
+		if ethRewards.Cmp(big.NewInt(0)) == 0 {
+			continue
+		}
 		cycleIndexes = append(cycleIndexes, big.NewInt(cycleInfo.MerkleProofInfo.Cycle))
 	}
 
@@ -65,14 +76,13 @@ func ClaimSpRewards(c *cli.Context) error {
 			if !ok {
 				return fmt.Errorf("Unable to parse eth rewards: %s", cycleInfo.MerkleProofInfo.Eth)
 			}
-			ethRewardsConverted := math.RoundDown(eth.WeiToEth(ethRewards), 2)
+			ethRewardsConverted := math.RoundDown(eth.WeiToEth(ethRewards), 5)
 			sdRewards, ok := big.NewInt(0).SetString(cycleInfo.MerkleProofInfo.Sd, 10)
 			if !ok {
 				return fmt.Errorf("Unable to parse sd rewards: %s", cycleInfo.MerkleProofInfo.Sd)
 			}
-			sdRewardsConverted := math.RoundDown(eth.WeiToEth(sdRewards), 2)
 
-			if ethRewardsConverted == 0 && sdRewardsConverted == 0 {
+			if ethRewards.Cmp(big.NewInt(0)) == 0 && sdRewards.Cmp(big.NewInt(0)) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
Currently, if a user wants to claim all the cycles at once. We also claim select cycles where there are no rewards. This will revert the tx since the contract fails such claims. To fix it we can just ignore cycles with no rewards